### PR TITLE
Add --enable-media-plugins as bug 714408 changed from enabled by default...

### DIFF
--- a/default-gecko-config
+++ b/default-gecko-config
@@ -42,6 +42,7 @@ ac_add_options --enable-updater
 #ac_add_options --enable-update-channel=nightly
 ac_add_options --enable-update-packaging
 
+ac_add_options --enable-media-plugins
 ac_add_options --enable-omx-plugin
 
 # Enable dump() from JS.


### PR DESCRIPTION
Bug 714408 changes the media plugins support from enabled by default to disabled. This requires "--enable-media-plugins" to be added along with the already existing "--enable-omx-plugin" for libstagefright decoding support to work. Bug 714408 is expected to land in the next day or so, pending review for the build changes.
