### PR TITLE
Make sure TMPDIR is created and 777.

### DIFF
--- a/b2g.sh
+++ b/b2g.sh
@@ -5,5 +5,5 @@ export LD_PRELOAD=/system/b2g/libmozglue.so
 export GRE_HOME=/system/b2g
 
 mkdir -p $TMPDIR
-chmod 777 $TMPDIR
+chmod 1777 $TMPDIR
 exec /system/b2g/b2g


### PR DESCRIPTION
CC @doublec

The gecko media cache wants to create cache files in TmpD, which is /data/local/tmp.  However, it doesn't have permission to do that.  This patch ensure TmpD is created and is 777 when b2g is launched.

We should consider destroying /data/local/tmp on startup, because otherwise I don't think it will ever be cleaned.  But that's work for another bug.

@michaelwu can you take a look?  Thanks.
