### PR TITLE
Bug 784805 - Script which shows the app name for plugin-container

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -62,6 +62,13 @@ LOCAL_SRC_FILES    := fakeperm.cpp
 LOCAL_SHARED_LIBRARIES := libbinder libutils
 include $(BUILD_EXECUTABLE)
 
+include $(CLEAR_VARS)
+LOCAL_MODULE       := b2g-ps
+LOCAL_MODULE_TAGS  := optional eng
+LOCAL_MODULE_CLASS := EXECUTABLES
+LOCAL_SRC_FILES    := b2g-ps
+include $(BUILD_PREBUILT)
+
 $(OUT_DOCS)/api-stubs-timestamp:
 	mkdir -p `dirname $@`
 	touch $@

--- a/b2g-ps
+++ b/b2g-ps
@@ -1,0 +1,11 @@
+#!/system/bin/sh
+# ps output is: user pid ppid vss rss wchan eip state cmdline
+
+ps | while read line; do
+  if [ "${line/*b2g*/b2g}" = "b2g" ]; then
+    echo ${line} | while read user pid rest; do
+      comm="$(cat /proc/${pid}/comm)                "
+      echo "${comm:0:16} ${line}"
+    done
+  fi
+done


### PR DESCRIPTION
This script needs https://bugzilla.mozilla.org/show_bug.cgi?id=784805 before its really useful, but it won't hurt anything to land it before that bug.
