### PR TITLE
Remove OMX plugin from gecko build

### DIFF
--- a/default-gecko-config
+++ b/default-gecko-config
@@ -46,8 +46,6 @@ ac_add_options --enable-updater
 #ac_add_options --enable-update-channel=nightly
 ac_add_options --enable-update-packaging
 
-ac_add_options --enable-media-plugins
-ac_add_options --enable-omx-plugin
 ac_add_options --enable-b2g-camera
 
 # Enable dump() from JS.


### PR DESCRIPTION
The builtin OMX decoder with zero-copy support will be landing soon in gecko. Need to disable the OMX plugin to prevent any conflicts once it does.
