### PR TITLE
disable IonMonkey for B2G builds fixes issue #33

### DIFF
--- a/default-gecko-config
+++ b/default-gecko-config
@@ -57,3 +57,6 @@ ac_add_options --enable-b2g-camera
 export CXXFLAGS="-DMOZ_ENABLE_JS_DUMP $EXTRA_INCLUDE"
 
 ac_add_options --with-fpu="$ARCH_ARM_VFP"
+
+# Disable IonMonkey for B2G because of regressions
+ac_add_options --disable-ion


### PR DESCRIPTION
This should fix issue #33 by disabling Ionmonkey for B2G build system driven builds.
