### PR TITLE
Add buildsymbols/uploadsymbols make targets that forward to the Gecko make targets

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -213,3 +213,7 @@ $(LOCAL_BUILT_MODULE): $(TARGET_CRTBEGIN_DYNAMIC_O) $(TARGET_CRTEND_O) $(addpref
 	rm -f $(GECKO_OBJDIR)/dist/b2g-*.tar.gz && \
 	$(MAKE) -C $(GECKO_OBJDIR) package && \
 	mkdir -p $(@D) && cp $(GECKO_OBJDIR)/dist/b2g-*.tar.gz $@
+
+.PHONY: buildsymbols uploadsymbols
+buildsymbols uploadsymbols:
+	$(MAKE) -C $(GECKO_OBJDIR) $@


### PR DESCRIPTION
We need these to get symbols uploaded for dogfood builds. I'll make these dump symbols for Gonk libraries as well in the near future, but getting Gecko symbols is a good start, and having the build targets gives RelEng something to call.
