### PR TITLE
Bug 805154 - Restrict what signals and to whom killer can send them.

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -80,6 +80,7 @@ LOCAL_MODULE       := killer
 LOCAL_MODULE_TAGS  := optional
 LOCAL_MODULE_CLASS := EXECUTABLES
 LOCAL_SRC_FILES    := killer.cpp
+LOCAL_FORCE_STATIC_EXECUTABLE := true	# since this is setuid root
 LOCAL_SHARED_LIBRARIES :=
 include $(BUILD_EXECUTABLE)
 

--- a/killer.cpp
+++ b/killer.cpp
@@ -19,14 +19,22 @@
  * processes.  The main difference is that, unlike the kill(1) implementation
  * on our devices, this program will happily send signals greater than 32.
  *
+ * This program has been restricted to only being able to send signals
+ * SIGRT0, SIGRT1, and SIGRT2 (32, 33, and 34) and furthermore it can only
+ * send them to processes launched from /system/b2g/b2g or
+ * /system/b2g/plugin-container. These restrictions were added to allow
+ * this program to be setuid(root) which would be required on a production
+ * phone which uses the shell user for the adb shell command (non-production
+ * phones use the root user for adb shell).
+ *
  * Example usages:
  *
- *     # Send signal 42 to processes 123, 456, and 789.
- *     $ killer 42 123 456 789
+ *     # Send signal 32 to processes 123, 456, and 789.
+ *     $ killer 32 123 456 789
  *
- *     # Send SIGRTMIN + 10 to process 123.  (We don't parse any of the
+ *     # Send SIGRTMIN + 2 to process 123.  (We don't parse any of the
  *     # friendly signal names other than "SIGRT".)
- *     $ killer SIGRT10 123
+ *     $ killer SIGRT2 123
  */
 
 #include <stdio.h>
@@ -34,8 +42,20 @@
 #include <assert.h>
 #include <signal.h>
 #include <malloc.h>
+#include <unistd.h>
 
 using namespace std;
+
+// Since we run as setuid root, we restrict which signals can be
+// sent and to whom we can send them.
+static const int  sAllowedSignals[] = {SIGRTMIN + 0, SIGRTMIN + 1, SIGRTMIN + 2 };
+
+static const char *sAllowedExes[] = {
+  "/system/b2g/b2g",
+  "/system/b2g/plugin-container"
+};
+
+#define ARRAY_LENGTH(x) (sizeof(x)/sizeof(x[0]))
 
 void usage(int argc, char** argv)
 {
@@ -44,10 +64,13 @@ void usage(int argc, char** argv)
   fprintf(stderr, "Usage: %s SIGRT<N> PID [PID...]\n", argv[0]);
   fprintf(stderr, "\n");
   fprintf(stderr, "For example,\n\n");
-  fprintf(stderr, "  %s SIGRT8 123\n\n", argv[0]);
-  fprintf(stderr, "will send signal SIGRTMIN + 8 to process 123.\n\n");
+  fprintf(stderr, "  %s SIGRT2 123\n\n", argv[0]);
+  fprintf(stderr, "will send signal SIGRTMIN + 2 to process 123.\n\n");
   fprintf(stderr, "(We don't parse parse any friendly signal names other than ");
   fprintf(stderr, "\"SIGRT\" at the moment.)\n");
+  fprintf(stderr, "\n");
+  fprintf(stderr, "This program can only send SIGRT0, SIGRT1, and SIGRT2 to\n");
+  fprintf(stderr, "the /system/b2g/b2g and /system/b2g/plugin-container programs.\n");
 }
 
 int main(int argc, char** argv)
@@ -87,6 +110,17 @@ int main(int argc, char** argv)
     usage(argc, argv);
     exit(1);
   }
+  bool foundAllowedSignal = false;
+  for (int i = 0; i < ARRAY_LENGTH(sAllowedSignals); i++) {
+    if (signum == sAllowedSignals[i]) {
+      foundAllowedSignal = true;
+      break;
+    }
+  }
+  if (!foundAllowedSignal) {
+    fprintf(stderr, "Error: Signal %s isn't allowed.\n", sigstr);
+    exit(1);
+  }
 
   /*
    * For some reason <vector> isn't in our include path.  Rather than figure
@@ -103,6 +137,32 @@ int main(int argc, char** argv)
       usage(argc, argv);
       exit(1);
     }
+    // We could use MAX_PATH_LEN, but this is 4K, and we know our strings
+    // can't possibly be that long, so we save some memory.
+    char path[64];
+    snprintf(path, sizeof(path), "/proc/%d/exe", pid);
+    char exe[64];
+    int linklen = readlink(path, exe, sizeof(exe));
+    if (linklen < 0) {
+      fprintf(stderr, "Error: No such process %s", argv[i]);
+      exit(1);
+    }
+    if (linklen > (sizeof(exe) - 1)) {
+      linklen = sizeof(exe) - 1;
+    }
+    exe[linklen] = '\0';
+    bool foundAllowedExe = false;
+    for (int i = 0; i < ARRAY_LENGTH(sAllowedExes); i++) {
+      if (strcmp(exe, sAllowedExes[i]) == 0) {
+        foundAllowedExe = true;
+        break;
+      }
+    }
+    if (!foundAllowedExe) {
+      fprintf(stderr, "Error: Process %s isn't allowed.\n", exe);
+      exit(1);
+    }
+
     pids[numPids] = pid;
     numPids++;
   }


### PR DESCRIPTION
This will allow us to make killer setuid root in the future, should
we decide to use this on production phones.

Note: killer is also now statically linked to close LD_LIBRARY_PATH
or LD_PRELOAD vulnerabilities.
