### PR TITLE
bug 774284 - The buildsymbols target should dump Gonk library symbols as well

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -227,6 +227,11 @@ $(LOCAL_BUILT_MODULE): $(TARGET_CRTBEGIN_DYNAMIC_O) $(TARGET_CRTEND_O) $(addpref
 	$(MAKE) -C $(GECKO_OBJDIR) package && \
 	mkdir -p $(@D) && cp $(GECKO_OBJDIR)/dist/b2g-*.tar.gz $@
 
+MAKE_SYM_STORE_PATH := \
+  $(abspath $(PRODUCT_OUT)/symbols) \
+  $(abspath $(GECKO_OBJDIR)/dist/bin) \
+  $(NULL)
+
 .PHONY: buildsymbols uploadsymbols
 buildsymbols uploadsymbols:
-	$(MAKE) -C $(GECKO_OBJDIR) $@
+	$(MAKE) -C $(GECKO_OBJDIR) $@ MAKE_SYM_STORE_PATH="$(MAKE_SYM_STORE_PATH)"


### PR DESCRIPTION
Simple change, just overrides the default directory that "make buildsymbols" operates on, appending the directory containing unstripped Gonk libraries. This should get us useful function symbols + unwind data.
