### PR TITLE
Don't strip gonk libraries while dumping symbols

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -241,6 +241,10 @@ MAKE_SYM_STORE_PATH := \
   $(abspath $(GECKO_OBJDIR)/dist/bin) \
   $(NULL)
 
+# Override the defaults so we don't try to strip
+# system libraries.
+MAKE_SYM_STORE_ARGS := --vcs-info
+
 .PHONY: buildsymbols uploadsymbols
 buildsymbols uploadsymbols:
-	$(MAKE) -C $(GECKO_OBJDIR) $@ MAKE_SYM_STORE_PATH="$(MAKE_SYM_STORE_PATH)"
+	$(MAKE) -C $(GECKO_OBJDIR) $@ MAKE_SYM_STORE_PATH="$(MAKE_SYM_STORE_PATH)" MAKE_SYM_STORE_ARGS="$(MAKE_SYM_STORE_ARGS)"


### PR DESCRIPTION
This might be causing build bustage.
