### PR TITLE
Bug 821194 - Let b2g.sh recover after a failed update by renaming /system/b2g.bak

### DIFF
--- a/b2g.sh
+++ b/b2g.sh
@@ -4,6 +4,27 @@ export TMPDIR=/data/local/tmp
 mkdir -p $TMPDIR
 chmod 1777 $TMPDIR
 
+if [ ! -d /system/b2g ]; then
+
+  log -p W "No /system/b2g directory. Attempting recovery."
+  if [ -d /system/b2g.bak ]; then
+    if ! mount -w -o remount /system; then
+      log -p E "Failed to remount /system read-write"
+    fi
+    if ! mv /system/b2g.bak /system/b2g; then
+      log -p E "Failed to rename /system/b2g.bak to /system/b2g"
+    fi
+    mount -r -o remount /system
+    if [ -d /system/b2g ]; then
+      log "Recovery successful."
+    else
+      log -p E "Recovery failed."
+    fi
+  else
+    log -p E "Recovery failed: no /system/b2g.bak directory."
+  fi
+fi
+
 LD_PRELOAD="/system/b2g/libmozglue.so"
 if [ -f "/system/b2g/libdmd.so" ]; then
   echo "Running with DMD."


### PR DESCRIPTION
Reviewed by: Dave Hylands
