### PR TITLE
Bug 814579: remove out-dated desktop debug trigger

### DIFF
--- a/init.b2g.rc
+++ b/init.b2g.rc
@@ -9,6 +9,5 @@ service b2g /system/bin/b2g.sh
 service rilproxy /system/bin/rilproxy
     class main
     socket rilproxy stream 660 root system
-    socket rilproxyd stream 660 root system
     user root
     group radio


### PR DESCRIPTION
This change is rooted for MultiSIM. In MultiSIM, we're going to have multiple rild and multiple rilproxy in Plan B. Some cleanups are also done in [rilproxy](https://github.com/mozilla-b2g/rilproxy/pull/25) and requested for merge. Each rilproxy opens its own socket for Gecko, /dev/socket/rilproxy, /dev/socket/rilproxy1, /dev/socket/rilproxy2, and so on. The original rilproxy also features a debug socket named /dev/socket/rilproxyd. However, this feature is also available in Gecko ipc/ril/ril.cpp. By removing this feature from rilproxy, we don't bother creating multiple debug sockets for rilproxy instances but still preserves the ability to debug RIL traffic through Gecko's way.
