### PR TITLE
Bug 835963 - Revert pull request 68 due to bustage

### DIFF
--- a/init.b2g.rc
+++ b/init.b2g.rc
@@ -9,5 +9,5 @@ service b2g /system/bin/b2g.sh
 service rilproxy /system/bin/rilproxy
     class main
     socket rilproxy stream 660 root system
-    user radio
+    user root
     group radio


### PR DESCRIPTION
The problem is this relies on a change in init.b2g.rc which requires a new kernel
