### PR TITLE
Bug 849103 - Remove redundant code used to disable IonMonkey.

### DIFF
--- a/default-gecko-config
+++ b/default-gecko-config
@@ -55,9 +55,6 @@ export CXXFLAGS="-DMOZ_ENABLE_JS_DUMP $EXTRA_INCLUDE ${CXXFLAGS}"
 
 ac_add_options --with-fpu="$ARCH_ARM_VFP"
 
-# Disable IonMonkey for B2G because of regressions
-ac_add_options --disable-ion
-
 if [ "${MOZ_DMD:-0}" != 0 ]; then
   ac_add_options --enable-dmd
 fi


### PR DESCRIPTION
@jhford

Can you review it as part of Bug 849103 ?
This patch remove the redundant code used to disable IonMonkey in B2G.  Another code is also used for that in js/src/configure.in in the gecko repository.
