### PR TITLE
Bug 853977- increase RLIMIT_NOFILE's soft limit to 2048 in init.b2g.rc

### DIFF
--- a/init.b2g.rc
+++ b/init.b2g.rc
@@ -14,3 +14,6 @@ service rilproxy /system/bin/rilproxy
 
 on boot
     exec /system/bin/rm -r /data/local/tmp
+    # set RLIMIT_NOFILE to increase soft limit from 1024(default) to 2048.
+    # Hard limit keeps default value(4096).
+    setrlimit 7 2048 4096


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=853977
