### PR TITLE
pass sources.xml to symbolstore.py to get source repo links in Breakpad symbols

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -271,7 +271,8 @@ MAKE_SYM_STORE_PATH := \
 
 # Override the defaults so we don't try to strip
 # system libraries.
-MAKE_SYM_STORE_ARGS := --vcs-info
+REPO_MANIFEST := $(abspath ./sources.xml)
+MAKE_SYM_STORE_ARGS := --vcs-info $(if $(wildcard $(REPO_MANIFEST)),--repo-manifest=$(REPO_MANIFEST))
 
 .PHONY: buildsymbols uploadsymbols
 buildsymbols uploadsymbols:


### PR DESCRIPTION
I had to fix a few issues in mozilla-central to get this working, but this gets us source links in crash reports for the Gonk bits of B2G.
https://bugzilla.mozilla.org/show_bug.cgi?id=866241
