### PR TITLE
Bug 869327 - B2G Emulator: Upgrade hardware/ril, external/qemu to include RILv7/CDMA

### DIFF
--- a/b2g.mk
+++ b/b2g.mk
@@ -11,6 +11,7 @@ PRODUCT_PACKAGES += \
 	init.rc \
 	init.b2g.rc \
 	killer \
+	rild \
 	rilproxy \
 	sources.xml \
 	$(NULL)


### PR DESCRIPTION
Please see [bug 869327](https://bugzilla.mozilla.org/show_bug.cgi?id=869327).
