### PR TITLE
Bug 867031 - [CustomizeUI] Cannot preload contacts during build time. r=mwu

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -181,9 +181,7 @@ ifeq ($(PRESERVE_B2G_WEBAPPS), 1)
 endif
 
 	mkdir -p $(TARGET_OUT)/b2g/defaults/pref
-# rename user_pref() to pref() in user.js
-	sed s/user_pref\(/pref\(/ $(GAIA_PATH)/profile/user.js > $(TARGET_OUT)/b2g/defaults/pref/user.js
-	cp $(GAIA_PATH)/profile/settings.json $(TARGET_OUT)/b2g/defaults/settings.json
+	cp -r $(GAIA_PATH)/profile/defaults/* $(TARGET_OUT)/b2g/defaults/
 
 	cd $(TARGET_OUT) && tar xvfz $(abspath $<)
 


### PR DESCRIPTION
This reverts commit e6beb3cf80ed83f12e1713799d9fcccca6f3a996.

This patch should merge after gaia part patch: https://github.com/mozilla-b2g/gaia/pull/9777.
Due to gaia part was merged, so this patch can be merged now.

see [Bug 867031](https://bugzilla.mozilla.org/show_bug.cgi?id=867031#c12).
