### PR TITLE
Bug 924147 - Enable dark matter detector on debug builds

### DIFF
--- a/default-gecko-config
+++ b/default-gecko-config
@@ -5,6 +5,10 @@ ENABLE_MARIONETTE=1
 ENABLE_TESTS=1
 fi
 
+if [ "$TARGET_BUILD_VARIANT" == "eng" ] ; then
+MOZ_DMD=1
+fi
+
 mk_add_options MOZ_OBJDIR="$GECKO_OBJDIR"
 
 # XXX our build system doesn't seem to respect toplevel -j ...


### PR DESCRIPTION
DMD is a tool for that tracks which heap blocks have been reported by memory reporters.
See https://wiki.mozilla.org/Performance/MemShrink/DMD for details.
