### PR TITLE
Bug 927274 - B2G NFC: Add NFC Daemon for Nexus4

### DIFF
--- a/init.b2g.rc
+++ b/init.b2g.rc
@@ -20,6 +20,10 @@ service rilproxy /system/bin/rilproxy
     user root
     group radio
 
+service nfcd /system/bin/nfcd
+    class main
+    oneshot
+
 on boot
     exec /system/bin/rm -r /data/local/tmp
     exec /system/bin/mkdir -p /data/local/tmp


### PR DESCRIPTION
According to Commit 10 from https://bugzilla.mozilla.org/show_bug.cgi?id=927274
put nfcd init in gonk-misk
