### PR TITLE
B2G NFC: NFC Daemon cannot connect to gecko

### DIFF
--- a/init.b2g.rc
+++ b/init.b2g.rc
@@ -23,6 +23,9 @@ service rilproxy /system/bin/rilproxy
 service nfcd /system/bin/nfcd
     class main
     oneshot
+    socket nfcd stream 660 nfc nfc
+    user nfc
+    group nfc
 
 on boot
     exec /system/bin/rm -r /data/local/tmp


### PR DESCRIPTION
NFC daemon code will use  android_get_control_socket API to get listen socket to connect with gecko.
