### PR TITLE
add PPID to default output for b2g-info

### DIFF
--- a/b2g-info/b2g-info.cpp
+++ b/b2g-info/b2g-info.cpp
@@ -241,6 +241,7 @@ b2g_ps_add_table_headers(Table& t, bool show_threads)
   t.start_row();
   t.add("NAME");
   t.add(show_threads ? "TID" : "PID");
+  t.add("PPID");
   t.add("NICE");
   t.add("USS");
   t.add("PSS");
@@ -277,6 +278,7 @@ print_b2g_info(bool show_threads)
     t.start_row();
     t.add(p->name());
     t.add(p->pid());
+    t.add(p->ppid());
     t.add(p->nice());
     t.add_fmt("%0.1f", p->uss_mb());
     t.add_fmt("%0.1f", p->pss_mb());


### PR DESCRIPTION
often in bug reports I see people include both b2g-ps output AND b2g-info output.  Often the reason for this is because PPID is important, especially in a Nuwa world (it's a great way to confirm that processes are forked from the Nuwa template process and not from b2g proper).

I think raising the visibility of the process architecture by including PPID in the default output of b2g-info could be useful, and we have plenty of horizontal space for it before we hit 72 chars.
