### PR TITLE
Cputime

### DIFF
--- a/b2g-info/b2g-info.cpp
+++ b/b2g-info/b2g-info.cpp
@@ -242,6 +242,7 @@ b2g_ps_add_table_headers(Table& t, bool show_threads)
   t.add("NAME");
   t.add(show_threads ? "TID" : "PID");
   t.add("PPID");
+  t.add("CPU(s)");
   t.add("NICE");
   t.add("USS");
   t.add("PSS");
@@ -279,6 +280,7 @@ print_b2g_info(bool show_threads)
     t.add(p->name());
     t.add(p->pid());
     t.add(p->ppid());
+    t.add_fmt("%0.1f", p->stime_s() + p->utime_s());
     t.add(p->nice());
     t.add_fmt("%0.1f", p->uss_mb());
     t.add_fmt("%0.1f", p->pss_mb());

--- a/b2g-info/process.cpp
+++ b/b2g-info/process.cpp
@@ -40,6 +40,8 @@ Task::Task(pid_t pid, pid_t tid)
   , m_got_stat(false)
   , m_ppid(-1)
   , m_nice(0)
+  , m_utime(-1)
+  , m_stime(-1)
 {
   char procdir[128];
   snprintf(procdir, sizeof(procdir), "/proc/%d/task/%d/", pid, tid);
@@ -73,10 +75,24 @@ Task::nice()
   return m_nice;
 }
 
+double
+Task::utime_s()
+{
+  ensure_got_stat();
+  return m_utime;
+}
+
+double
+Task::stime_s()
+{
+  ensure_got_stat();
+  return m_stime;
+}
+
 void
 Task::ensure_got_stat()
 {
-  static const unsigned int NUM_CAPTURES = 5;
+  static const unsigned int NUM_CAPTURES = 7;
   const char* pattern =
     "^"           // beginning of string
     "([0-9]+) "   // pid
@@ -92,8 +108,8 @@ Task::ensure_got_stat()
     "[0-9]+ "     // cminflt (%lu)
     "[0-9]+ "     // majflt (%lu)
     "[0-9]+ "     // cmajflt (%lu)
-    "[0-9]+ "     // utime (%lu)
-    "[0-9]+ "     // stime (%ld)
+    "([0-9]+) "   // utime (%lu)
+    "([0-9]+) "   // stime (%ld)
     "[0-9]+ "     // cutime (%ld)
     "[0-9]+ "     // cstime (%ld)
     "[0-9]+ "     // priority (%ld)
@@ -152,7 +168,9 @@ Task::ensure_got_stat()
   m_name.clear();
   m_name.append(buf + pmatch[2].rm_so, pmatch[2].rm_eo - pmatch[2].rm_so);
   m_ppid = strtol(buf + pmatch[3].rm_so, NULL, 10);
-  m_nice = strtol(buf + pmatch[4].rm_so, NULL, 10);
+  m_nice = strtol(buf + pmatch[6].rm_so, NULL, 10);
+  m_utime = ticks_to_secs(strtol(buf + pmatch[4].rm_so, NULL, 10));
+  m_stime = ticks_to_secs(strtol(buf + pmatch[5].rm_so, NULL, 10));
 
   // finally, emit an error if the line we read doesn't correspond
   // to the process we expect

--- a/b2g-info/process.h
+++ b/b2g-info/process.h
@@ -47,6 +47,9 @@ public:
    */
   pid_t task_id();
 
+  double stime_s();
+  double utime_s();
+
 protected:
   Task(pid_t pid);
   Task(pid_t pid, pid_t tid);
@@ -63,6 +66,9 @@ protected:
   bool m_got_stat;
   pid_t m_ppid;
   int m_nice;
+
+  double m_utime;
+  double m_stime;
 
   std::string m_name;
 };

--- a/b2g-info/utils.cpp
+++ b/b2g-info/utils.cpp
@@ -32,6 +32,8 @@ using namespace std;
 
 long sPageSize = sysconf(_SC_PAGESIZE);
 
+long hertz = sysconf(_SC_CLK_TCK);
+
 /**
  * Convert a number of pages to kb.
  *
@@ -58,6 +60,20 @@ double kb_to_mb(int kb)
   }
 
   return kb / 1024.0;
+}
+
+/**
+ * Convert a number of clock ticks into seconds.
+ *
+ * -1 signifies an error, so if ticks == -1, return -1.
+ */
+double ticks_to_secs(int ticks)
+{
+  if (ticks == -1) {
+    return -1;
+  }
+
+  return ticks / (double) hertz;
 }
 
 /**

--- a/b2g-info/utils.h
+++ b/b2g-info/utils.h
@@ -39,6 +39,13 @@ int pages_to_kb(int pages);
 double kb_to_mb(int kb);
 
 /**
+ * Convert a number of clock ticks into seconds.
+ *
+ * -1 signifies an error, so if ticks == -1, return -1.
+ */
+double ticks_to_secs(int ticks);
+
+/**
  * Strip whitespace off the beginning and end of the given string.
  */
 void strip(std::string& str);


### PR DESCRIPTION
depends on pull request #130

Would display CPU time utilized per process in seconds (user + system time).

like this:

```
                           |    megabytes    |
           NAME PID CPU(s) NICE  USS  PSS  RSS VSIZE OOM_ADJ USER   
            b2g 112   43.1    0 48.6 52.4 64.3 158.1       0 root   
         (Nuwa) 249    1.1    1  4.4 10.2 23.4  51.6       2 root   
          Usage 352    1.6   18 11.8 15.1 26.3  66.0      10 app_352
     Homescreen 391    3.3   18 15.2 18.9 30.4  70.7       8 app_391
(Preallocated a 455    0.1   18  2.9  6.9 14.3  55.6      10 root   
```
