### PR TITLE
adding POWERTEST config var to include power-test utilities

### DIFF
--- a/b2g.mk
+++ b/b2g.mk
@@ -39,3 +39,7 @@ ifneq ($(DISABLE_SOURCES_XML),true)
 PRODUCT_PACKAGES += \
 	sources.xml
 endif
+
+ifneq ($(POWERTEST),)
+include external/i2c-tools/i2c-tools.mk
+endif


### PR DESCRIPTION
this is needed to include i2c-tools into the b2g build for powertesting.  The charging circuits are managed via the i2c bus.