### PR TITLE
Bug 946674 - Building emulator on darwin x86 leads to failure make: *** ...

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -340,7 +340,6 @@ EMULATOR_FILES := \
 	$(HOST_OUT)/bin/mksdcard \
 	$(HOST_OUT)/bin/qemu-android-x86 \
 	$(HOST_OUT)/lib \
-	$(HOST_OUT)/usr \
 	development/tools/emulator/skins \
 	prebuilts/qemu-kernel/arm/kernel-qemu-armv7 \
 	$(PRODUCT_OUT)/system/build.prop \


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=946674
