### PR TITLE
Bug 964196: Give nfcd access to wake locks

### DIFF
--- a/init.b2g.rc
+++ b/init.b2g.rc
@@ -25,7 +25,7 @@ service nfcd /system/bin/nfcd
     oneshot
     socket nfcd stream 660 nfc nfc
     user nfc
-    group nfc
+    group system
 
 on boot
     exec /system/bin/rm -r /data/local/tmp


### PR DESCRIPTION
This patch changes the group of the nfcd process to 'system', so
that nfcd has access to the wake-lock interface in /sys/power/.

Signed-off-by: Thomas Zimmermann tdz@users.sourceforge.net
