### PR TITLE
Include in mar names, because they're uploaded to common directories.

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -219,7 +219,7 @@ endif
 
 # Target to create Gecko update package (MAR)
 DIST_B2G_UPDATE_DIR := $(GECKO_OBJDIR)/dist/b2g-update
-UPDATE_PACKAGE_TARGET := $(DIST_B2G_UPDATE_DIR)/b2g-gecko-update.mar
+UPDATE_PACKAGE_TARGET := $(DIST_B2G_UPDATE_DIR)/b2g-$(TARGET_DEVICE)-gecko-update.mar
 MAR := $(GECKO_OBJDIR)/dist/host/bin/mar
 MAKE_FULL_UPDATE := $(GECKO_PATH)/tools/update-packaging/make_full_update.sh
 


### PR DESCRIPTION
As part of switching over B2G updates to our production-grade update server we'll end up uploading MARs to common directories like https://ftp.mozilla.org/pub/mozilla.org/b2g/nightly/2014-04-25-04-02-03-mozilla-central/. Because we'll be doing this for the gecko+gaia bits on multiple different devices, we need to make sure the files don't stomp on each other. This patch should do that. I tested it by hand to make sure that $(PRODUCT_MODEL) was available in this Makefile.

Relevant bugs:
https://bugzilla.mozilla.org/show_bug.cgi?id=1000207
https://bugzilla.mozilla.org/show_bug.cgi?id=918068
