### PR TITLE
Bug 1002346 - Show swap usage in b2g-info

### DIFF
--- a/b2g-info/process.cpp
+++ b/b2g-info/process.cpp
@@ -205,6 +205,7 @@ Process::Process(pid_t pid)
   , m_rss_kb(-1)
   , m_pss_kb(-1)
   , m_uss_kb(-1)
+  , m_swap_kb(-1)
 {}
 
 pid_t
@@ -336,7 +337,7 @@ Process::ensure_got_meminfo()
     return;
   }
 
-  m_vsize_kb = m_rss_kb = m_pss_kb = m_uss_kb = 0;
+  m_vsize_kb = m_rss_kb = m_pss_kb = m_uss_kb = m_swap_kb = 0;
 
   char line[256];
   while(fgets(line, sizeof(line), f)) {
@@ -350,6 +351,8 @@ Process::ensure_got_meminfo()
       } else if (sscanf(line, "Private_Dirty: %d kB", &val) == 1 ||
                  sscanf(line, "Private_Clean: %d kB", &val) == 1) {
         m_uss_kb += val;
+      } else if (sscanf(line, "Swap: %d kB", &val) == 1) {
+        m_swap_kb += val;
       }
   }
 
@@ -382,6 +385,13 @@ Process::uss_kb()
 {
   ensure_got_meminfo();
   return m_uss_kb;
+}
+
+int
+Process::swap_kb()
+{
+  ensure_got_meminfo();
+  return m_swap_kb;
 }
 
 const string&

--- a/b2g-info/process.h
+++ b/b2g-info/process.h
@@ -120,6 +120,9 @@ public:
   int uss_kb();
   double uss_mb() { return kb_to_mb(uss_kb()); }
 
+  int swap_kb();
+  double swap_mb() { return kb_to_mb(swap_kb()); }
+
   const std::string& user();
 
 private:
@@ -140,6 +143,7 @@ private:
   int m_rss_kb;
   int m_pss_kb;
   int m_uss_kb;
+  int m_swap_kb;
 
   std::string m_user;
 };


### PR DESCRIPTION
It would be useful to know how much swap space are used by each process. On devices with swap enabled, what RSS measures are more like working sets. The memory pages a process committed are more close to RSS + Swap.

https://bugzilla.mozilla.org/show_bug.cgi?id=1002346
