### PR TITLE
Bug 1007570 - Improve fstab type heuristic detection

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -364,14 +364,25 @@ endef
 
 FSTAB_TYPE := recovery
 # $(1): recovery_fstab
+#
+# Android recovery fstab file format is like:
+# /system ext4 /dev/...
+#
+# Linux fstab file format is like:
+# /dev/... /system ext4
+#
+# We will first probe for any line starting with /dev that contains
+# /system. If we find any, it means we have a Linux fstab.
+# Otherwise it means it's an Android recovery fstab.
 define detect-partitions
   $(eval FSTAB_FILE := $(basename $(notdir $(1))))
 
   $(if $(FSTAB_FILE),
-    $(if $(filter fstab, $(FSTAB_FILE)),
+    $(eval STARTS_WITH_DEV := $(shell grep '^/dev/' $(1) | grep '/system'))
+    $(if $(filter /system, $(STARTS_WITH_DEV)),
       $(eval FSTAB_TYPE := linux))
 
-    $(info Extracting partitions from $(FSTAB_TYPE) fstab)
+    $(info Extracting partitions from $(FSTAB_TYPE) fstab ($(1)))
 
     $(if $(filter linux, $(FSTAB_TYPE)),
       $(eval B2G_FOTA_SYSTEM_PARTITION := $(shell grep -v '^\#' $(1) | grep '\s\+/system\s\+' | awk '{ print $$1 }'))


### PR DESCRIPTION
The Flame seems to rely on a recovery fstab that follows the Linux file
format but is named like an Android recovery file format fstab. This
makes out previous heuristic failing to correctly extracts the
partitions. Hence, we switch to something a bit more robust there:
- probe the fstab file for any line that contains '/system' and that
  starts with '/dev'
- if we find any such line, then it means this fstab file follows linux
  file format, and we extract the partition from the first member of
  the file
- if we don't findany, it means we have an fstab file that follows
  Android file format, and we extract the partition from the third
  member of the file
