### PR TITLE
Bug 1037211 - Remove redundant --enable-content-sandbox-reporter.

### DIFF
--- a/default-gecko-config
+++ b/default-gecko-config
@@ -77,7 +77,6 @@ ac_add_options --disable-elf-hack
 fi
 
 if [ "$TARGET_BUILD_VARIANT" = eng ]; then
-  ac_add_options --enable-content-sandbox-reporter
   # bug 979947 - Engineering builds should have
   # the profiler enabled by default
   ac_add_options --enable-profiling


### PR DESCRIPTION
It's enabled by default on B2G as of bug 979590, so this shouldn't
change anything.
