### PR TITLE
Bug 1054331 - Build valgrind only when B2G_VALGRIND=1

### DIFF
--- a/b2g.mk
+++ b/b2g.mk
@@ -23,7 +23,7 @@ PRODUCT_PACKAGES += \
 -include external/svox/pico/lang/all_pico_languages.mk
 -include gaia/gaia.mk
 
-ifneq ($(B2G_VALGRIND),)
+ifeq ($(B2G_VALGRIND),1)
 include external/valgrind/valgrind.mk
 endif
 


### PR DESCRIPTION
The b2g.mk script only checked if B2G_VALGRIND variable was empty, so
even when it was set to 0, valgrind was built.

Now we check  if the B2G_VALGRIND value is 1.
