### PR TITLE
fixes Bug 1043324 - add JSON output to b2g-info

### DIFF
--- a/b2g-info/Android.mk
+++ b/b2g-info/Android.mk
@@ -19,7 +19,7 @@ include external/stlport/libstlport.mk
 LOCAL_MODULE       := b2g-info
 LOCAL_MODULE_TAGS  := optional
 LOCAL_MODULE_CLASS := EXECUTABLES
-LOCAL_SRC_FILES    := b2g-info.cpp process.cpp processlist.cpp table.cpp utils.cpp
+LOCAL_SRC_FILES    := b2g-info.cpp json.cpp process.cpp processlist.cpp table.cpp utils.cpp
 LOCAL_FORCE_STATIC_EXECUTABLE := false
 LOCAL_SHARED_LIBRARIES := libstlport
 include $(BUILD_EXECUTABLE)

--- a/b2g-info/json.cpp
+++ b/b2g-info/json.cpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2013 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Enable assertions.
+#ifdef NDEBUG
+#undef NDEBUG
+#endif
+
+#include "json.h"
+
+using namespace JSON;
+
+void Object::add( std::string const & k, std::string const & v )
+{
+  members[k] = "\"" + v + "\"";
+}
+
+void Object::add( std::string const & k, bool v )
+{
+  std::string const val((v ? "true" : "false"));
+  members[k] = val;
+}
+
+
+void Array::push_back( std::string const & v )
+{
+  members.push_back("\"" + v + "\"");
+}
+
+void Array::push_back( bool v )
+{
+  std::string const val((v ? "true" : "false"));
+  members.push_back(val);
+}
+
+

--- a/b2g-info/json.h
+++ b/b2g-info/json.h
@@ -1,0 +1,129 @@
+/*
+ * Copyright (C) 2013 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <map>
+#include <vector>
+#include <string>
+#include <sstream>
+
+/**
+ * A simple class for accumulating data to output in JSON format.
+ *
+ * Example use:
+ *
+ *   JSON::Object obj, tmp
+ *   JSON::Array arr;
+ *
+ *   tmp.add("foo", "bar");
+ *   arr.push_back(1);
+ *   arr.push_back("blah");
+ *
+ *   obj.add("key1", "value");
+ *   obj.add("key2", 1234);
+ *   obj.add("key3", tmp);
+ *   obj.add("key4", arr);
+ *   obj.add("key5", true);
+ *   obj.add("key6", JSON::Null);
+ *
+ *   std::cout << obj << std::endl;
+ *
+ * This prints the following JSON:
+ *
+ * { "key1":"value", "key2": 1234, "key3": { "foo": "bar" }, "key4": [ 1, "blah" ], "key5": true, "key6": null }
+ * 
+ */
+
+namespace JSON {
+
+std::string const Null = "null";
+
+class Object {
+  typedef std::map<std::string, std::string>::const_iterator const_iterator;
+
+  public:
+    Object() {}
+    Object( Object const & rhs ) : members(rhs.members) {}
+    
+    void add( std::string const &, std::string const & );
+    void add( std::string const &, bool );
+
+    // use stringstream to convert the value to a string
+    template< typename T >
+    void add( std::string k, const T& v ) {
+      std::stringstream ss;
+      ss << v;
+      members[k] = ss.str();
+    }
+
+    friend std::ostream& operator<<( std::ostream& out, Object const & obj ) {
+      Object::const_iterator bgn = obj.members.begin();
+      Object::const_iterator end = obj.members.end();
+      out << "{ ";
+
+      for ( Object::const_iterator itr = bgn; itr != end; ++itr ) {
+        out << ((itr != bgn) ? ", " : "") 
+            << "\"" << itr->first << "\": " << itr->second;
+      }
+
+      out << " }";
+      return out;
+    }
+
+  private:
+    std::map<std::string, std::string> members;
+};
+
+class Array {
+  typedef std::vector<std::string>::const_iterator const_iterator;
+
+  public:
+    Array() {}
+    Array( Array const & rhs ) : members(rhs.members) {}
+
+    void push_back( std::string const & );
+    void push_back( bool );
+
+    // use stringstream to convert the parameter to a string first
+    template< typename T >
+    void push_back( const T& v ) {
+      std::stringstream ss;
+      ss << v;
+      members.push_back( ss.str() );
+    }
+
+    friend std::ostream& operator<<( std::ostream& out, Array const & arr ) {
+      Array::const_iterator bgn = arr.members.begin();
+      Array::const_iterator end = arr.members.end();
+      
+      out << "[ ";
+
+      for ( Array::const_iterator itr = bgn; itr != end; ++itr ) {
+        out << ((itr != bgn) ? ", " : "")
+            << (*itr);
+      }
+
+      out << " ]";
+      return out;
+    }
+        
+  private:
+    std::vector<std::string> members;
+};
+
+}
+  

--- a/b2g-info/process.cpp
+++ b/b2g-info/process.cpp
@@ -113,7 +113,7 @@ Task::ensure_got_stat()
     "[0-9]+ "     // cutime (%ld)
     "[0-9]+ "     // cstime (%ld)
     "[0-9]+ "     // priority (%ld)
-    "([0-9]+)";   // niceness
+    "-?([0-9]+)"; // niceness can be -20 to 20
 
   if (m_got_stat) {
     return;

--- a/b2g-info/process.h
+++ b/b2g-info/process.h
@@ -79,6 +79,7 @@ protected:
 class Thread : public Task
 {
 public:
+  typedef std::vector<Thread*>::const_iterator const_iterator;
   Thread(pid_t pid, pid_t tid);
   pid_t tid();
 
@@ -92,6 +93,7 @@ private:
 class Process : public Task
 {
 public:
+  typedef std::vector<Process*>::const_iterator const_iterator;
   Process(pid_t pid);
   pid_t pid();
 

--- a/b2g-info/processlist.cpp
+++ b/b2g-info/processlist.cpp
@@ -73,9 +73,8 @@ ProcessList::main_process()
     return m_main_process;
   }
 
-  const vector<Process*>& processes = all_processes();
-  for (vector<Process*>::const_iterator it = processes.begin();
-       it != processes.end(); ++it) {
+  for (Process::const_iterator it = all_processes().begin();
+       it != all_processes().end(); ++it) {
     if ((*it)->exe() == "/system/b2g/b2g") {
       if (m_main_process == NULL) {
         m_main_process = *it;
@@ -111,7 +110,7 @@ ProcessList::child_processes()
   // whose |exe|s are "/system/b2g/plugin-container".  As an added bonus, this
   // will work properly with nested content processes.
 
-  for (vector<Process*>::const_iterator it = all_processes().begin();
+  for (Process::const_iterator it = all_processes().begin();
        it != all_processes().end(); ++it) {
     if ((*it)->exe() == "/system/b2g/plugin-container") {
       m_child_processes.push_back(*it);
@@ -132,7 +131,7 @@ ProcessList::b2g_processes()
   m_b2g_processes.push_back(main_process());
 
   // There's no AppendAll()-type function on stl::vector, seriously?
-  for (vector<Process*>::const_iterator it = child_processes().begin();
+  for (Process::const_iterator it = child_processes().begin();
        it != child_processes().end(); ++it) {
     m_b2g_processes.push_back(*it);
   }


### PR DESCRIPTION
This adds a -j/--json option to b2g-info which causes it to output JSON.  The -j switch can be used in conjunction with other switches.