### PR TITLE
Bug 1022928 - Build symbols for vendor libs.

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -299,6 +299,7 @@ $(LOCAL_BUILT_MODULE): $(TARGET_CRTBEGIN_DYNAMIC_O) $(TARGET_CRTEND_O) $(addpref
 
 MAKE_SYM_STORE_PATH := \
   $(abspath $(PRODUCT_OUT)/symbols) \
+  $(abspath $(PRODUCT_OUT)/system/vendor/lib) \
   $(abspath $(GECKO_OBJDIR)/dist/bin) \
   $(NULL)
 


### PR DESCRIPTION
Include the vendor libraries directory in the buildsymbols path.
