### PR TITLE
Bug 1014659 - Copy cppunit zip during package-tests

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -328,7 +328,7 @@ package-tests:
 	mkdir $(TEST_DIR)
 	cp gaia/gaia-tests.zip $(TEST_DIR)
 	$(MAKE) -C $(GECKO_OBJDIR) package-tests && \
-	cp $(GECKO_OBJDIR)/dist/*.tests.zip $(TEST_DIR)
+	cp $(GECKO_OBJDIR)/dist/*.tests*zip $(TEST_DIR)
 	cd $(GECKO_PATH)/testing && zip -r $(TEST_DIR)/gaia-tests.zip marionette/client/* mozbase/*
 
 EMULATOR_FILES := \


### PR DESCRIPTION
I'm currently working on running the cppunit tests from their own test package [1]. The naming convention I'm using for the package is _.tests.cppunit.zip which doesn't get picked up by the copy statement in package-tests. Changing *.tests.zip to *.tests_zip fixes this and will cover any future separate test packages following the same naming convention.

[1] https://bugzilla.mozilla.org/show_bug.cgi?id=1014659
