### PR TITLE
Bug 1119746: Include Bluetooth init scripts, r=mwu

### DIFF
--- a/b2g.mk
+++ b/b2g.mk
@@ -9,6 +9,7 @@ PRODUCT_PACKAGES += \
 	b2g-ps \
 	bluetoothd \
 	gonksched \
+	init.bluetooth.rc \
 	fakeappops \
 	fs_config \
 	gaia \

--- a/init.b2g.rc
+++ b/init.b2g.rc
@@ -1,3 +1,6 @@
+
+import /init.bluetooth.rc
+
 service gonksched /system/bin/gonksched
     class main
     user root


### PR DESCRIPTION
The Bluetooth init script adds rules for starting and stopping
the Bluetooth daemon. The init script comes with bluetoothd,
but there is also a version for BlueZ 5 support.

Signed-off-by: Thomas Zimmermann <tdz@users.sourceforge.net>