### PR TITLE
Bug 1121986: Run rilproxy as non-root user

### DIFF
--- a/init.b2g.rc
+++ b/init.b2g.rc
@@ -12,9 +12,9 @@ service b2g /system/bin/b2g.sh
 
 service rilproxy /system/bin/rilproxy
     class main
-    socket rilproxy stream 660 root system
-    user root
-    group radio
+    socket rilproxy stream 660 radio radio
+    user radio
+    group radio system
 
 service nfcd /system/bin/nfcd
     class main


### PR DESCRIPTION
Rilproxy now re-uses init's socket for communicating with Gecko. We
don't need to run it as root user. This patch changes rilproxy to
run as user 'radio' with groups of 'radio' and 'system'. The socket's
permissions are also lowered to 'radio:radio'.