### PR TITLE
Bug 1109592: Don't start nfcd during boot

### DIFF
--- a/init.b2g.rc
+++ b/init.b2g.rc
@@ -21,10 +21,10 @@ service rilproxy /system/bin/rilproxy
 
 service nfcd /system/bin/nfcd
     class main
-    oneshot
-    socket nfcd stream 660 nfc nfc
     user nfc
     group system
+    disabled
+    oneshot
 
 on boot
     exec /system/bin/rm -r /data/local/tmp


### PR DESCRIPTION
With this patch, init will not start nfcd during boot. Gecko will
request the start up of nfcd when it is required.