### PR TITLE
Detail memory report

### DIFF
--- a/b2g-info/b2g-info.cpp
+++ b/b2g-info/b2g-info.cpp
@@ -303,11 +303,11 @@ print_b2g_info(bool show_threads)
     t.add(p->ppid());
     t.add_fmt("%0.1f", p->stime_s() + p->utime_s());
     t.add(p->nice());
-    t.add_fmt("%0.1f", p->uss_mb());
-    t.add_fmt("%0.1f", p->pss_mb());
-    t.add_fmt("%0.1f", p->rss_mb());
-    t.add_fmt("%0.1f", p->swap_mb());
-    t.add_fmt("%0.1f", p->vsize_mb());
+    t.add_fmt("%0.3f", p->uss_mb());
+    t.add_fmt("%0.3f", p->pss_mb());
+    t.add_fmt("%0.3f", p->rss_mb());
+    t.add_fmt("%0.3f", p->swap_mb());
+    t.add_fmt("%0.3f", p->vsize_mb());
     t.add(p->oom_adj());
     t.add(p->user(), Table::ALIGN_LEFT);
 


### PR DESCRIPTION
With latest raptor we finally have really good memory reports with low stdev (blow 40kb). Unfortunately, the level of precision reported by b2g-info is really low (100kb) which makes it impossible to debug and track down regressions that accumulate to 100-150kb.

This patch increases the precision of the memory report and allows us to use the low stdev to notice regressions better.