### PR TITLE
Bug 1221803 - Reduce system_data_file permissions r=kang

### DIFF
--- a/b2g.mk
+++ b/b2g.mk
@@ -37,6 +37,7 @@ BOARD_SEPOLICY_UNION += \
 	nfcd.te \
 	plugin-container.te \
 	rilproxy.te \
+	file.te \
 	file_contexts
 endif
 

--- a/sepolicy/b2g.te
+++ b/sepolicy/b2g.te
@@ -20,6 +20,11 @@ unix_socket_connect(b2g, rild, rild)
 # used to load libmozglue.so
 allow b2g plugin-container:process { noatsecure };
 
+# Files created, inside a directory labeled with 'system_data_file'
+# (such as /data/local/), by a processes running with in the b2g context,
+# should be labled with 'b2g_data_file'
+file_type_auto_trans(b2g, system_data_file, b2g_data_file)
+
 # audit2allow
 allow b2g adb_keys_file:dir { read write getattr open };
 allow b2g alarm_device:chr_file write;
@@ -131,11 +136,7 @@ allow b2g surfaceflinger_service:service_manager add;
 allow b2g sysfs:file write;
 allow b2g sysfs_lowmemorykiller:file { write open };
 allow b2g sysfs_wake_lock:file { read write open };
-allow b2g system_data_file:dir { open setattr rename read write rmdir remove_name create add_name };
-allow b2g system_data_file:fifo_file { open read setattr create getattr unlink };
-allow b2g system_data_file:file { rename setattr lock create write unlink open append };
-allow b2g system_data_file:lnk_file { create unlink };
-allow b2g system_data_file:sock_file { create setattr getattr unlink };
+allow b2g system_data_file:dir { remove_name add_name };
 allow b2g system_file:file execute_no_trans;
 allow b2g systemkeys_data_file:dir { write read open getattr };
 allow b2g system_prop:property_service set;

--- a/sepolicy/file.te
+++ b/sepolicy/file.te
@@ -1,0 +1,5 @@
+# Filesystem types
+
+# File types
+# Default type for anything inside /data/b2g
+type b2g_data_file, file_type, data_file_type;

--- a/sepolicy/file_contexts
+++ b/sepolicy/file_contexts
@@ -1,11 +1,22 @@
 #############################
-# B2G files
+# B2G data files
 #
-/system/bin/b2g.sh	u:object_r:b2g_exec:s0
-/system/b2g/b2g		u:object_r:b2g_exec:s0
-/system/b2g/plugin-container	u:object_r:plugin-container_exec:s0
-/system/bin/gonksched	u:object_r:gonksched_exec:s0
-/system/bin/rilproxy 	u:object_r:rilproxy_exec:s0
-/system/bin/fakeappops	u:object_r:fakeappops_exec:s0
-/system/bin/bluetoothd	u:object_r:bluetoothd_exec:s0
-/system/bin/nfcd	u:object_r:nfcd_exec:s0
+/data/b2g(/.*)?                 u:object_r:b2g_data_file:s0
+
+# Misc files
+/data/local/permissions.sqlite  u:object_r:b2g_data_file:s0
+
+# Webapps
+/data/local/webapps(/.*)?       u:object_r:b2g_data_file:s0
+
+#############################
+# B2G executables
+#
+/system/bin/b2g.sh              u:object_r:b2g_exec:s0
+/system/b2g/b2g                 u:object_r:b2g_exec:s0
+/system/b2g/plugin-container    u:object_r:plugin-container_exec:s0
+/system/bin/gonksched           u:object_r:gonksched_exec:s0
+/system/bin/rilproxy            u:object_r:rilproxy_exec:s0
+/system/bin/fakeappops          u:object_r:fakeappops_exec:s0
+/system/bin/bluetoothd          u:object_r:bluetoothd_exec:s0
+/system/bin/nfcd                u:object_r:nfcd_exec:s0


### PR DESCRIPTION
Reduce the system_data_file permissions for the b2g domain by creating a separate file type for b2g related data files and label files/directories accordingly on the file system.