### PR TITLE
Remove --enable-update-packaging

### DIFF
--- a/default-gecko-config
+++ b/default-gecko-config
@@ -60,8 +60,6 @@ if [ "${B2G_UPDATER:-0}" != "0" ]; then
   ac_add_options --enable-update-channel="${B2G_UPDATE_CHANNEL}"
 fi
 
-ac_add_options --enable-update-packaging
-
 # Enable dump() from JS.
 export CXXFLAGS="-DMOZ_ENABLE_JS_DUMP $EXTRA_INCLUDE ${CXXFLAGS}"
 


### PR DESCRIPTION
This is not supported upstream anymore, and breaks when running configure.